### PR TITLE
Bump gocardless-pro to v3.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 def dependencyVersions = [
-    goCardless: '3.6.0',
+    goCardless: '3.7.0',
     dropwizard: '1.1.0'
 ]
 


### PR DESCRIPTION
Use gocardless-pro v3.7.0, which adds support for passing customer address fields to the Mandate PDFs creation endpoint.
