### PR TITLE
Revert "Bump com.github.johnrengelman.shadow from 1.2.4 to 5.2.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
+    id 'com.github.johnrengelman.shadow' version '1.2.4'
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
Reverts gocardless/gocardless-pro-java-example#30

This needs a newer version of Gradle.